### PR TITLE
Fix GradScaler + Perceptual Loss

### DIFF
--- a/neosr/models/default.py
+++ b/neosr/models/default.py
@@ -206,8 +206,8 @@ class default():
             use_amp = True
         if self.opt['bfloat16'] is True:
             amp_dtype = torch.bfloat16
-
-        scaler = torch.cuda.amp.GradScaler(enabled=use_amp)
+            
+        scaler = torch.cuda.amp.GradScaler(enabled=use_amp, init_scale=2**10)
 
         with torch.autocast(device_type='cuda', dtype=amp_dtype, enabled=use_amp):
             self.output = self.net_g(self.lq)
@@ -243,25 +243,17 @@ class default():
                     l_g_gan = self.cri_gan(fake_g_pred, True, is_disc=False)
                     l_g_total += l_g_gan
                     loss_dict['l_g_gan'] = l_g_gan
+                # perceptual loss
+                if self.cri_perceptual:
+                    l_g_percep, l_g_style = self.cri_perceptual(self.output, self.gt)
+                    if l_g_percep is not None:
+                        l_g_total += l_g_percep
+                        loss_dict['l_percep'] = l_g_percep
+                    if l_g_style is not None:
+                        l_g_total += l_g_style
+                        loss_dict['l_style'] = l_g_style
 
 
-        # TODO: workaround for perceptual loss. See issue:
-        # https://github.com/muslll/neosr/issues/4
-
-        if (current_iter % self.net_d_iters == 0 and current_iter > self.net_d_init_iters):
-            # perceptual loss
-            l_g_total_p = 0
-            if self.cri_perceptual:
-                l_g_percep, l_g_style = self.cri_perceptual(self.output, self.gt)
-                if l_g_percep is not None:
-                    l_g_total_p += l_g_percep
-                    loss_dict['l_percep'] = l_g_percep
-                if l_g_style is not None:
-                    l_g_total_p += l_g_style
-                    loss_dict['l_style'] = l_g_style
-
-        if self.cri_perceptual:
-            l_g_total_p.backward(retain_graph=True)
         scaler.scale(l_g_total).backward()
         scaler.step(self.optimizer_g)
         scaler.update()


### PR DESCRIPTION
Reduced the init_scale of GradScaler to 2**10,  by lowering the scaling value, GradScaler no longer produces invalid values and ensures that optimizer.step() is executed correctly. This in turn resolves the warning for calling lr_scheduler.step() before optimizer.step().