### PR TITLE
Fix Unsupported ScalarType BFloat16

### DIFF
--- a/neosr/utils/color_util.py
+++ b/neosr/utils/color_util.py
@@ -1,7 +1,6 @@
 import numpy as np
 import torch
 
-
 def rgb2ycbcr(img, y_only=False):
     """Convert a RGB image to YCbCr image.
 
@@ -16,8 +15,8 @@ def rgb2ycbcr(img, y_only=False):
 
     Args:
         img (ndarray): The input image. It accepts:
-            1. np.uint8 type with range [0, 255];
-            2. np.float32 type with range [0, 1].
+            1. torch.uint8 type with range [0, 255];
+            2. torch.float32 type with range [0, 1].
         y_only (bool): Whether to only return Y channel. Default: False.
 
     Returns:
@@ -29,7 +28,7 @@ def rgb2ycbcr(img, y_only=False):
     if y_only:
         out_img = np.dot(img, [65.481, 128.553, 24.966]) + 16.0
     else:
-        out_img = np.matmul(
+        out_img = torch.matmul(
             img, [[65.481, -37.797, 112.0], [128.553, -74.203, -93.786], [24.966, 112.0, -18.214]]) + [16, 128, 128]
     out_img = _convert_output_type_range(out_img, img_type)
     return out_img
@@ -49,8 +48,8 @@ def bgr2ycbcr(img, y_only=False):
 
     Args:
         img (ndarray): The input image. It accepts:
-            1. np.uint8 type with range [0, 255];
-            2. np.float32 type with range [0, 1].
+            1. torch.uint8 type with range [0, 255];
+            2. torch.float32 type with range [0, 1].
         y_only (bool): Whether to only return Y channel. Default: False.
 
     Returns:
@@ -62,7 +61,7 @@ def bgr2ycbcr(img, y_only=False):
     if y_only:
         out_img = np.dot(img, [24.966, 128.553, 65.481]) + 16.0
     else:
-        out_img = np.matmul(
+        out_img = torch.matmul(
             img, [[24.966, 112.0, -18.214], [128.553, -74.203, -93.786], [65.481, -37.797, 112.0]]) + [16, 128, 128]
     out_img = _convert_output_type_range(out_img, img_type)
     return out_img
@@ -82,8 +81,8 @@ def ycbcr2rgb(img):
 
     Args:
         img (ndarray): The input image. It accepts:
-            1. np.uint8 type with range [0, 255];
-            2. np.float32 type with range [0, 1].
+            1. torch.uint8 type with range [0, 255];
+            2. torch.float32 type with range [0, 1].
 
     Returns:
         ndarray: The converted RGB image. The output image has the same type
@@ -91,7 +90,7 @@ def ycbcr2rgb(img):
     """
     img_type = img.dtype
     img = _convert_input_type_range(img) * 255
-    out_img = np.matmul(img, [[0.00456621, 0.00456621, 0.00456621], [0, -0.00153632, 0.00791071],
+    out_img = torch.matmul(img, [[0.00456621, 0.00456621, 0.00456621], [0, -0.00153632, 0.00791071],
                               [0.00625893, -0.00318811, 0]]) * 255.0 + [-222.921, 135.576, -276.836]  # noqa: E126
     out_img = _convert_output_type_range(out_img, img_type)
     return out_img
@@ -111,8 +110,8 @@ def ycbcr2bgr(img):
 
     Args:
         img (ndarray): The input image. It accepts:
-            1. np.uint8 type with range [0, 255];
-            2. np.float32 type with range [0, 1].
+            1. torch.uint8 type with range [0, 255];
+            2. torch.float32 type with range [0, 1].
 
     Returns:
         ndarray: The converted BGR image. The output image has the same type
@@ -120,7 +119,7 @@ def ycbcr2bgr(img):
     """
     img_type = img.dtype
     img = _convert_input_type_range(img) * 255
-    out_img = np.matmul(img, [[0.00456621, 0.00456621, 0.00456621], [0.00791071, -0.00153632, 0],
+    out_img = torch.matmul(img, [[0.00456621, 0.00456621, 0.00456621], [0.00791071, -0.00153632, 0],
                               [0, -0.00318811, 0.00625893]]) * 255.0 + [-276.836, 135.576, -222.921]  # noqa: E126
     out_img = _convert_output_type_range(out_img, img_type)
     return out_img
@@ -129,56 +128,56 @@ def ycbcr2bgr(img):
 def _convert_input_type_range(img):
     """Convert the type and range of the input image.
 
-    It converts the input image to np.float32 type and range of [0, 1].
+    It converts the input image to torch.float32 type and range of [0, 1].
     It is mainly used for pre-processing the input image in colorspace
     conversion functions such as rgb2ycbcr and ycbcr2rgb.
 
     Args:
         img (ndarray): The input image. It accepts:
-            1. np.uint8 type with range [0, 255];
-            2. np.float32 type with range [0, 1].
+            1. torch.uint8 type with range [0, 255];
+            2. torch.float32 type with range [0, 1].
 
     Returns:
-        (ndarray): The converted image with type of np.float32 and range of
+        (ndarray): The converted image with type of torch.float32 and range of
             [0, 1].
     """
     img_type = img.dtype
-    img = img.astype(np.float32)
-    if img_type == np.float32:
+    img = img.astype(torch.float32)
+    if img_type == torch.float32:
         pass
-    elif img_type == np.uint8:
+    elif img_type == torch.uint8:
         img /= 255.
     else:
         raise TypeError(
-            f'The img type should be np.float32 or np.uint8, but got {img_type}')
+            f'The img type should be torch.float32 or torch.uint8, but got {img_type}')
     return img
 
 
 def _convert_output_type_range(img, dst_type):
     """Convert the type and range of the image according to dst_type.
 
-    It converts the image to desired type and range. If `dst_type` is np.uint8,
-    images will be converted to np.uint8 type with range [0, 255]. If
-    `dst_type` is np.float32, it converts the image to np.float32 type with
+    It converts the image to desired type and range. If `dst_type` is torch.uint8,
+    images will be converted to torch.uint8 type with range [0, 255]. If
+    `dst_type` is torch.float32, it converts the image to torch.float32 type with
     range [0, 1].
     It is mainly used for post-processing images in colorspace conversion
     functions such as rgb2ycbcr and ycbcr2rgb.
 
     Args:
-        img (ndarray): The image to be converted with np.float32 type and
+        img (ndarray): The image to be converted with torch.float32 type and
             range [0, 255].
-        dst_type (np.uint8 | np.float32): If dst_type is np.uint8, it
-            converts the image to np.uint8 type with range [0, 255]. If
-            dst_type is np.float32, it converts the image to np.float32 type
+        dst_type (torch.uint8 | torch.float32): If dst_type is torch.uint8, it
+            converts the image to torch.uint8 type with range [0, 255]. If
+            dst_type is torch.float32, it converts the image to torch.float32 type
             with range [0, 1].
 
     Returns:
         (ndarray): The converted image with desired type and range.
     """
-    if dst_type not in (np.uint8, np.float32):
+    if dst_type not in (torch.uint8, torch.float32):
         raise TypeError(
-            f'The dst_type should be np.float32 or np.uint8, but got {dst_type}')
-    if dst_type == np.uint8:
+            f'The dst_type should be torch.float32 or torch.uint8, but got {dst_type}')
+    if dst_type == torch.uint8:
         img = img.round()
     else:
         img /= 255.
@@ -228,11 +227,12 @@ def rgb_to_linear_rgb(img: torch.Tensor) -> torch.Tensor:
     if len(img.shape) < 3 or img.shape[-3] != 3:
         raise ValueError(f"Input size must have a shape of (*, 3, H, W).Got {img.shape}")
 
-    img = img.cpu().detach().numpy()
+    img = img.cpu().detach().to(torch.float32).numpy()
+    img = torch.from_numpy(img)
     gamma = ((img + 0.055) / 1.055)**2.4
     scale = img / 12.92
-    lin_rgb = np.where (img > 0.04045, gamma, scale)
-    lin_rgb = torch.tensor(lin_rgb)
+    lin_rgb = torch.where (img > 0.04045, gamma, scale)
+    lin_rgb = lin_rgb.clone().detach()
 
     return lin_rgb
 


### PR DESCRIPTION
Also converted most numpy functions to torch for uniformity. Error can be reproduced by enabling color loss on DITN (or maybe just in general)