### PR TITLE
Improve SPAN stability greatly

### DIFF
--- a/neosr/archs/span_arch.py
+++ b/neosr/archs/span_arch.py
@@ -211,13 +211,15 @@ class span(nn.Module):
                  feature_channels=48,
                  upscale=upscale,
                  bias=True,
-                 img_range=255.
+                 img_range=1.,
+                 rgb_mean=(0.4488, 0.4371, 0.4040)
                  ):
         super(span, self).__init__()
 
         in_channels = num_in_ch
         out_channels = num_out_ch
         self.img_range = img_range
+        self.mean = torch.Tensor(rgb_mean).view(1, 3, 1, 1)
 
         self.conv_1 = Conv3XC(in_channels, feature_channels, gain1=2, s=1)
         self.block_1 = SPAB(feature_channels, bias=bias)
@@ -233,6 +235,9 @@ class span(nn.Module):
         self.upsampler = pixelshuffle_block(feature_channels, out_channels, upscale_factor=upscale)
 
     def forward(self, x):
+        self.mean = self.mean.type_as(x)
+        x = (x - self.mean) * self.img_range
+
         out_feature = self.conv_1(x)
 
         out_b1, _, att1 = self.block_1(out_feature)

--- a/neosr/archs/span_arch.py
+++ b/neosr/archs/span_arch.py
@@ -211,7 +211,7 @@ class span(nn.Module):
                  feature_channels=48,
                  upscale=upscale,
                  bias=True,
-                 img_range=255.)
+                 img_range=255.
                  ):
         super(span, self).__init__()
 

--- a/neosr/archs/span_arch.py
+++ b/neosr/archs/span_arch.py
@@ -211,15 +211,13 @@ class span(nn.Module):
                  feature_channels=48,
                  upscale=upscale,
                  bias=True,
-                 img_range=255.,
-                 rgb_mean=(0.4488, 0.4371, 0.4040)
+                 img_range=255.)
                  ):
         super(span, self).__init__()
 
         in_channels = num_in_ch
         out_channels = num_out_ch
         self.img_range = img_range
-        self.mean = torch.Tensor(rgb_mean).view(1, 3, 1, 1)
 
         self.conv_1 = Conv3XC(in_channels, feature_channels, gain1=2, s=1)
         self.block_1 = SPAB(feature_channels, bias=bias)
@@ -235,9 +233,6 @@ class span(nn.Module):
         self.upsampler = pixelshuffle_block(feature_channels, out_channels, upscale_factor=upscale)
 
     def forward(self, x):
-        self.mean = self.mean.type_as(x)
-        x = (x - self.mean) * self.img_range
-
         out_feature = self.conv_1(x)
 
         out_b1, _, att1 = self.block_1(out_feature)


### PR DESCRIPTION
The rgb_mean code seems to decrease the stability of SPAN and not have any major meaningful effect on the end result model's RGB output.
Removing the code improves the stability during training by a large margin.
I have attached logs to compare the training up to 5000 iterations with the same settings except the rgb_mean code removed from SPAN's arch file.
Also here is [an imgsli album](https://imgsli.com/MjM1MzE4) for visually comparing 1k stages up to 5k.

This code may benefit other archs using this code. I will create a separate pull request with it removed from all arch files containing it, as I have not tested them for similar improvement.

[rgb_mean_enabled_log.txt](https://github.com/muslll/neosr/files/14038132/rgb_mean_enabled_log.txt)
[rgb_mean_disabled_log.txt](https://github.com/muslll/neosr/files/14038133/rgb_mean_disabled_log.txt)
