### PR TITLE
Fix SPAN parameter detection tensor

### DIFF
--- a/neosr/archs/span_arch.py
+++ b/neosr/archs/span_arch.py
@@ -222,11 +222,11 @@ class span(nn.Module):
         self.img_range = img_range
         self.mean = torch.Tensor(rgb_mean).view(1, 3, 1, 1)
 
-        self.norm: Tensor | None
-        if norm:
-            self.register_buffer("norm", torch.zeros(1))
+        self.no_norm: torch.Tensor | None
+        if not norm:
+            self.register_buffer("no_norm", torch.zeros(1))
         else:
-            self.norm = None
+            self.no_norm = None
 
         self.conv_1 = Conv3XC(in_channels, feature_channels, gain1=2, s=1)
         self.block_1 = SPAB(feature_channels, bias=bias)
@@ -241,8 +241,9 @@ class span(nn.Module):
 
         self.upsampler = pixelshuffle_block(feature_channels, out_channels, upscale_factor=upscale)
 
+    @property
     def is_norm(self):
-        return self.norm is not None
+        return self.no_norm is None
 
     def forward(self, x):
         if self.is_norm:


### PR DESCRIPTION
Sorry, @muslll. I was wrong in #25. As I said there:

> we register the tensor only if norm=False

I just didn't notice this when looking at your commit.