### PR TITLE
Fix OTF training

### DIFF
--- a/neosr/models/default.py
+++ b/neosr/models/default.py
@@ -232,6 +232,10 @@ class default():
         losses_for_backward_g = []
 
         with torch.autocast(device_type='cuda', dtype=self.amp_dtype, enabled=self.use_amp):
+            if self.opt['train'].get('type', 'otf') is 'otf':
+                self.gt = self.gt.clone().requires_grad_()
+                self.lq = self.lq.clone().requires_grad_()
+
             self.output = self.net_g(self.lq)
 
             l_g_total = 0


### PR DESCRIPTION
OTF training is broken due to inference mode being used for data augmentation. This causes the GT and LQ tensors to become inference tensors, unable to be used outside of inference mode.

One solution is to use no_grad instead of inference_mode for the OTF augmentation process. The other is to create a clone of the inference tensors with tensor.clone().requires_grad() in order to make a non-inference tensor.

This PR adds code to the optimize_parameters function that checks if OTF is being used, and if so, creates non-inference clones of the GT and LQ tensors.