### PR TITLE
Enable paired datasets for OTF training, make crop_pad_size dynamic

### DIFF
--- a/neosr/data/otf_dataset.py
+++ b/neosr/data/otf_dataset.py
@@ -9,7 +9,8 @@ import torch
 from torch.utils import data
 
 from neosr.data.degradations import circular_lowpass_kernel, random_mixed_kernels
-from neosr.data.transforms import basic_augment
+from neosr.data.transforms import basic_augment, paired_random_crop
+from neosr.data.data_util import paired_paths_from_folder, paired_paths_from_lmdb
 from neosr.utils import FileClient, get_root_logger, imfrombytes, img2tensor, scandir
 from neosr.utils.registry import DATASET_REGISTRY
 
@@ -38,30 +39,60 @@ class otf(data.Dataset):
         self.file_client = None
         self.io_backend_opt = opt['io_backend']
         self.gt_folder = opt['dataroot_gt']
+        # mean and std for normalizing the input images
+        self.mean = opt['mean'] if 'mean' in opt else None
+        self.std = opt['std'] if 'std' in opt else None
+        self.is_paired = False
 
         if opt.get('dataroot_lq', None) is not None:
-            raise ValueError("'dataroot_lq' not supported by otf, please switch to paired")
+            self.lq_folder = opt['dataroot_lq']
+            self.filename_tmpl = opt['filename_tmpl'] if 'filename_tmpl' in opt else '{}'
+            self.is_paired = True
 
         # file client (lmdb io backend)
         if self.io_backend_opt['type'] == 'lmdb':
-            self.io_backend_opt['db_paths'] = [self.gt_folder]
-            self.io_backend_opt['client_keys'] = ['gt']
-            if not self.gt_folder.endswith('.lmdb'):
-                raise ValueError(
-                    f"'dataroot_gt' should end with '.lmdb', but received {self.gt_folder}")
-            with open(osp.join(self.gt_folder, 'meta_info.txt')) as fin:
-                self.paths = [line.split('.')[0] for line in fin]
+            if self.is_paired:
+                self.io_backend_opt['db_paths'] = [self.lq_folder, self.gt_folder]
+                self.io_backend_opt['client_keys'] = ['lq', 'gt']
+                self.paths = paired_paths_from_lmdb(
+                    [self.lq_folder, self.gt_folder], ['lq', 'gt'])
+            else:
+                self.io_backend_opt['db_paths'] = [self.gt_folder]
+                self.io_backend_opt['client_keys'] = ['gt']
+            if self.is_paired:
+                if not self.gt_folder.endswith('.lmdb'):
+                    raise ValueError(
+                        f"'dataroot_gt' should end with '.lmdb', but received {self.gt_folder}")
+                with open(osp.join(self.gt_folder, 'meta_info.txt')) as fin:
+                    self.paths = [line.split('.')[0] for line in fin]
         elif 'meta_info' in self.opt and self.opt['meta_info'] is not None:
             # disk backend with meta_info
             # Each line in the meta_info describes the relative path to an image
-            with open(self.opt['meta_info']) as fin:
-                paths = [line.strip().split(' ')[0] for line in fin]
-                self.paths = [os.path.join(self.gt_folder, v) for v in paths]
+
+                if self.is_paired:
+                    with open(self.opt['meta_info']) as fin:
+                        paths = [line.strip() for line in fin]
+                    self.paths = []
+                    for path in paths:
+                        gt_path, lq_path = path.split(', ')
+                        gt_path = os.path.join(self.gt_folder, gt_path)
+                        lq_path = os.path.join(self.lq_folder, lq_path)
+                        self.paths.append(
+                            dict([('gt_path', gt_path), ('lq_path', lq_path)]))
+                else:
+                    with open(self.opt['meta_info']) as fin:
+                        paths = [line.strip().split(' ')[0] for line in fin]
+                        self.paths = [os.path.join(self.gt_folder, v) for v in paths]
+
         else:
             # disk backend
             # it will scan the whole folder to get meta info
             # it will be time-consuming for folders with too many files. It is recommended using an extra meta txt file
-            self.paths = sorted(list(scandir(self.gt_folder, full_path=True)))
+            if not self.is_paired:
+                self.paths = sorted(list(scandir(self.gt_folder, full_path=True)))
+            else:
+                self.paths = paired_paths_from_folder([self.lq_folder, self.gt_folder], [
+                    'lq', 'gt'], self.filename_tmpl)
 
         # blur settings for the first degradation
         self.blur_kernel_size = opt['blur_kernel_size']
@@ -102,56 +133,125 @@ class otf(data.Dataset):
             self.file_client = FileClient(
                 self.io_backend_opt.pop('type'), **self.io_backend_opt)
 
-        # -------------------------------- Load gt images -------------------------------- #
-        # Shape: (h, w, c); channel order: BGR; image range: [0, 1], float32.
-        gt_path = self.paths[index]
-        # avoid errors caused by high latency in reading files
-        retry = 3
-        while retry > 0:
-            try:
-                img_bytes = self.file_client.get(gt_path, 'gt')
-                if img_bytes is None:
-                    raise ValueError(f'No data returned from path: {gt_path}')
-            except (IOError, OSError) as e:
-                logger = get_root_logger()
-                logger.warn(
-                    f'File client error: {e} in path {gt_path}, remaining retry times: {retry - 1}')
-                # change another file to read
-                index = random.randint(0, self.__len__())
-                gt_path = self.paths[index]
-                time.sleep(1)  # sleep 1s for occasional server congestion
-            else:
-                break
-            finally:
-                retry -= 1
+        # -------------------------------- Load lq & gt images -------------------------------- #
+        scale = self.opt['scale']
+        if not self.is_paired:
+            gt_path = self.paths[index]
+        else:
+            gt_path = self.paths[index]['gt_path']
+        # Load gt and lq images. Dimension order: HWC; channel order: BGR;
+        # image range: [0, 1], float32.
+
+        img_bytes = self.file_client.get(gt_path, 'gt')
 
         try:
             img_gt = imfrombytes(img_bytes, float32=True)
         except AttributeError:
             raise AttributeError(gt_path)
 
+        if self.is_paired:
+            gt_path = self.paths[index]['gt_path']
+            lq_path = self.paths[index]['lq_path']
+            img_bytes = self.file_client.get(lq_path, 'lq')
+
+            try:
+                img_lq = imfrombytes(img_bytes, float32=True)
+            except AttributeError:
+                raise AttributeError(lq_path)
+
+            # avoid errors caused by high latency in reading files
+            retry = 3
+            while retry > 0:
+                try:
+                    if img_bytes is None:
+                        raise ValueError(f'No data returned from path: {gt_path}, {lq_path}')
+                except (IOError, OSError) as e:
+                    logger = get_root_logger()
+                    logger.warn(
+                        f'File client error: {e} in paths {gt_path}, {lq_path}, remaining retry times: {retry - 1}')
+                    # change another file to read
+                    index = random.randint(0, self.__len__())
+                    gt_path = gt_path[index]
+                    time.sleep(1)  # sleep 1s for occasional server congestion
+                else:
+                    break
+                finally:
+                    retry -= 1
+
+        else:
+            # avoid errors caused by high latency in reading files
+            retry = 3
+            while retry > 0:
+                try:
+                    if img_bytes is None:
+                        raise ValueError(f'No data returned from path: {gt_path}')
+                except (IOError, OSError) as e:
+                    logger = get_root_logger()
+                    logger.warn(f'File client error: {e} in paths {gt_path}, remaining retry times: {retry - 1}')
+                    # change another file to read
+                    index = random.randint(0, self.__len__())
+                    gt_path = gt_path[index]
+                    time.sleep(1)  # sleep 1s for occasional server congestion
+                else:
+                    break
+                finally:
+                    retry -= 1
+
 
         # -------------------- Do augmentation for training: flip, rotation -------------------- #
-        img_gt = basic_augment(img_gt, self.opt['use_hflip'], self.opt['use_rot'])
+        gt_size = self.opt['gt_size']
+        if self.is_paired:
+            # random crop
+            img_gt, img_lq = paired_random_crop(
+                img_gt, img_lq, gt_size, scale, gt_path)
+            # flip, rotation
+            img_gt, img_lq = basic_augment(
+                [img_gt, img_lq], self.opt['use_hflip'], self.opt['use_rot'])
+        else:
+            img_gt = basic_augment(img_gt, self.opt['use_hflip'], self.opt['use_rot'])
 
-        # crop or pad to 512
-        # TODO: 512 is hard-coded. You may change it accordingly
-        h, w = img_gt.shape[0:2]
-        crop_pad_size = 512
+        # crop or pad
+        if self.is_paired:
+            h, w = img_lq.shape[0:2]
+            img_pad = img_lq
+        else:
+            h, w = img_gt.shape[0:2]
+            img_pad = img_gt
+
+        crop_pad_size = max(h, w)
+        if (crop_pad_size) > 512 and not self.is_paired:
+            crop_pad_size = 512
+        elif (crop_pad_size) > 128 and self.is_paired:
+            crop_pad_size = 128
+        else:
+            # addition required for reflection pad later
+            crop_pad_size = crop_pad_size + 32
+
         # pad
         if h < crop_pad_size or w < crop_pad_size:
             pad_h = max(0, crop_pad_size - h)
             pad_w = max(0, crop_pad_size - w)
-            img_gt = cv2.copyMakeBorder(
-                img_gt, 0, pad_h, 0, pad_w, cv2.BORDER_REFLECT_101)
+            img_pad = cv2.copyMakeBorder(
+                img_pad, 0, pad_h, 0, pad_w, cv2.BORDER_REFLECT_101)
+            if self.is_paired:
+                pad_gt_h = max(0, (crop_pad_size * scale) - (h * scale))
+                pad_gt_w = max(0, (crop_pad_size * scale) - (w * scale))
+                img_gt = cv2.copyMakeBorder(
+                img_gt, 0, pad_gt_h, 0, pad_gt_w, cv2.BORDER_REFLECT_101)
         # crop
-        if img_gt.shape[0] > crop_pad_size or img_gt.shape[1] > crop_pad_size:
-            h, w = img_gt.shape[0:2]
+        if img_pad.shape[0] > crop_pad_size or img_pad.shape[1] > crop_pad_size:
+            h, w = img_pad.shape[0:2]
             # randomly choose top and left coordinates
             top = random.randint(0, h - crop_pad_size)
             left = random.randint(0, w - crop_pad_size)
-            img_gt = img_gt[top:top + crop_pad_size,
+            img_pad = img_pad[top:top + crop_pad_size,
                             left:left + crop_pad_size, ...]
+            if self.is_paired:
+                # randomly choose top and left coordinates
+                top = random.randint(0, (h * scale) - (crop_pad_size * scale))
+                left = random.randint(0, (w * scale) - (crop_pad_size * scale))
+                img_gt = img_gt[top:top + (crop_pad_size * scale),
+                          left:left + (crop_pad_size * scale), ...]
 
         # ------------------------ Generate kernels (used in the first degradation) ------------------------ #
         rng = np.random.default_rng()
@@ -213,14 +313,21 @@ class otf(data.Dataset):
             sinc_kernel = self.pulse_tensor
 
         # BGR to RGB, HWC to CHW, numpy to tensor
-        img_gt = img2tensor([img_gt], bgr2rgb=True, float32=True)[0]
+        img_pad = img2tensor([img_pad], bgr2rgb=True, float32=True)[0]
+        if self.is_paired:
+            img_gt = img2tensor([img_gt], bgr2rgb=True, float32=True)[0]
         # NOTE: using torch.tensor(device='cuda') won't work.
         # Keeping old constructor for now.
         kernel = torch.FloatTensor(kernel)
         kernel2 = torch.FloatTensor(kernel2)
 
-        return_d = {'gt': img_gt, 'kernel1': kernel, 'kernel2': kernel2,
-                    'sinc_kernel': sinc_kernel, 'gt_path': gt_path}
+        if self.is_paired:
+            return_d = {'gt': img_gt, 'lq': img_pad, 'kernel1': kernel, 'kernel2': kernel2,
+                        'sinc_kernel': sinc_kernel, 'gt_path': gt_path, 'lq_path': lq_path}
+        else:
+            return_d = {'gt': img_pad, 'kernel1': kernel, 'kernel2': kernel2,
+                        'sinc_kernel': sinc_kernel, 'gt_path': gt_path}
+
         return return_d
 
     def __len__(self):

--- a/neosr/data/otf_dataset.py
+++ b/neosr/data/otf_dataset.py
@@ -212,12 +212,11 @@ class otf(data.Dataset):
 
         # crop or pad
         if self.is_paired:
-            h, w = img_lq.shape[0:2]
             img_pad = img_lq
         else:
-            h, w = img_gt.shape[0:2]
             img_pad = img_gt
 
+        h, w = img_pad.shape[0:2]
         crop_pad_size = max(h, w)
         if (crop_pad_size) > 512 and not self.is_paired:
             crop_pad_size = 512

--- a/options/train_compact_otf.yml
+++ b/options/train_compact_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_craft_otf.yml
+++ b/options/train_craft_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_cugan_otf.yml
+++ b/options/train_cugan_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_dat_otf.yml
+++ b/options/train_dat_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_dctlsa_otf.yml
+++ b/options/train_dctlsa_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_ditn_otf.yml
+++ b/options/train_ditn_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_hat_otf.yml
+++ b/options/train_hat_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_omnisr_otf.yml
+++ b/options/train_omnisr_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_realesrgan_otf.yml
+++ b/options/train_realesrgan_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_rgt_otf.yml
+++ b/options/train_rgt_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_safmn_otf.yml
+++ b/options/train_safmn_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_span_otf.yml
+++ b/options/train_span_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_srformer_otf.yml
+++ b/options/train_srformer_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true

--- a/options/train_swinir_otf.yml
+++ b/options/train_swinir_otf.yml
@@ -7,8 +7,6 @@ bfloat16: false
 fast_matmul: false
 compile: false
 #manual_seed: 1024
-
-gt_size: 128
 queue_size: 180
 
 datasets:
@@ -19,6 +17,7 @@ datasets:
     io_backend:
       type: disk
 
+    gt_size: 128
     batch_size: 6
     accumulate: 1
     use_hflip: true


### PR DESCRIPTION
This is my OTF code for allowing paired datasets to use OTF.

It also makes the crop_pad_size dynamic rather than hard-coded to 512. Now the padding will be based off the longest side to a maximum of 512 for GT sized images, and 128 for LQ images.