### PR TITLE
Limit scan in generate_meta_info_pairdata.py to image types

### DIFF
--- a/dataset/util/generate_meta_info_pairdata.py
+++ b/dataset/util/generate_meta_info_pairdata.py
@@ -1,13 +1,20 @@
+import itertools
 import argparse
-import glob
 import os
+
+from pathlib import Path
+
+
+def scan_images(input_path):
+    root = Path(input_path)
+    globs = (root.glob(f"*.{ext}") for ext in ("png", "jpg", "jpeg", "webp"))
+    return sorted(itertools.chain.from_iterable(globs))
 
 
 def main(args):
     txt_file = open(args.meta_info, 'w')
-    # sca images
-    img_paths_gt = sorted(glob.glob(os.path.join(args.input[0], '*')))
-    img_paths_lq = sorted(glob.glob(os.path.join(args.input[1], '*')))
+    img_paths_gt = scan_images(args.input[0])
+    img_paths_lq = scan_images(args.input[1])
 
     assert len(img_paths_gt) == len(img_paths_lq), ('GT folder and LQ folder should have the same length, but got '
                                                     f'{len(img_paths_gt)} and {len(img_paths_lq)}.')


### PR DESCRIPTION
Sometimes non-image files can sneak into dataset folders (like `desktop.ini` on windows) which can disrupt training. Therefore this change limits the scan when generating a paired dataset to only consider known image type extensions.