### PR TITLE
Fix resuming current_iter

### DIFF
--- a/train.py
+++ b/train.py
@@ -122,7 +122,8 @@ def load_resume_state(opt):
             resume_state_path = opt["path"]["resume_state"]
 
     if resume_state_path is None:
-        resume_state = None
+        resume_state = {'epoch': 0, 'iter': 0,
+                    'optimizers': [], 'schedulers': []}
     else:
         resume_state = torch.load(resume_state_path, map_location=torch.device("cuda"))
         check_resume(opt, resume_state["iter"])
@@ -156,7 +157,7 @@ def train_pipeline(root_path):
     # load resume states if necessary
     resume_state = load_resume_state(opt)
     # mkdir for experiments and logger
-    if resume_state is None:
+    if resume_state["iter"] == 0:
         make_exp_dirs(opt)
         if (
             opt["logger"].get("use_tb_logger")
@@ -189,7 +190,7 @@ def train_pipeline(root_path):
     # create model
     model = build_model(opt)
 
-    if resume_state:  # resume training
+    if resume_state["iter"] != 0:  # resume training
         model.resume_training(resume_state)  # handle optimizers and schedulers
         logger.info(
             f"Resuming training from epoch: {resume_state['epoch']}, iter: {int(resume_state['iter'])}."

--- a/train.py
+++ b/train.py
@@ -195,7 +195,7 @@ def train_pipeline(root_path):
             f"Resuming training from epoch: {resume_state['epoch']}, iter: {int(resume_state['iter'])}."
         )
         start_epoch = resume_state["epoch"]
-        current_iter = int(resume_state["iter"])
+        current_iter = int(resume_state["iter"] * opt["datasets"]["train"].get("accumulate", 1))
         #current_iter = resume_state["iter"]
         torch.cuda.empty_cache()
     else:
@@ -213,7 +213,7 @@ def train_pipeline(root_path):
         logger.info("AMP enabled.")
 
     # training
-    logger.info(f"Start training from epoch: {start_epoch}, iter: {int(current_iter)}")
+    logger.info(f"Start training from epoch: {start_epoch}, iter: {int(resume_state['iter'])}")
     data_timer, iter_timer = AvgTimer(), AvgTimer()
     start_time = time.time()
 

--- a/train.py
+++ b/train.py
@@ -195,7 +195,7 @@ def train_pipeline(root_path):
             f"Resuming training from epoch: {resume_state['epoch']}, iter: {int(resume_state['iter'])}."
         )
         start_epoch = resume_state["epoch"]
-        current_iter = int(resume_state["iter"] * opt["datasets"]["train"].get("accumulate", 1))
+        current_iter = int(resume_state["iter"])
         #current_iter = resume_state["iter"]
         torch.cuda.empty_cache()
     else:


### PR DESCRIPTION
Currently the logger notes that it will start training from current_iter * accumulate when resuming a model. This leads to the logger showing the wrong number in the "Start training from epoch...." line.

I've changed it to read resume_state['iter'] instead, so the correct value is printed.