### PR TITLE
Accumulate losses

### DIFF
--- a/neosr/models/default.py
+++ b/neosr/models/default.py
@@ -289,7 +289,7 @@ class default():
         loss_dict['l_g_total'] = l_g_total
 
         loss_g = l_g_total / self.accum_iters
-        self.scaler_g.scale(loss_g).backward(retain_graph = not is_last_loss)
+        self.scaler_g.scale(loss_g).backward
 
         if apply_gradient:
             # gradient clipping on generator


### PR DESCRIPTION
The generator losses can be accumulated into l_g_total and have a single scale.backward() run on them, as was done until recently. Lower-level gradients do not get overwritten, and scale only needs to be run on each loss individually if they are not summed.