### PR TITLE
Update readme - remove 'dat_light' arch option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Please read the wiki [Configuration Walkthrough](https://github.com/muslll/neosr
 | [HAT](https://github.com/XPixelGroup/HAT)                                                         | `hat_s`, `hat_m`, `hat_l`              		|
 | [OmniSR](https://github.com/Francis0625/Omni-SR)                                                  | `omnisr`                               		|
 | [SRFormer](https://github.com/HVision-NKU/SRFormer)                                               | `srformer_light`, `srformer_medium`    		|
-| [DAT](https://github.com/zhengchen1999/dat)                                                       | `dat_light`, `dat_small`, `dat_medium`, `dat_2` 	|
+| [DAT](https://github.com/zhengchen1999/dat)                                                       | `dat_small`, `dat_medium`, `dat_2` 		|
 | [DITN](https://github.com/yongliuy/DITN)							    | `ditn`				     	      	|
 | [DCTLSA](https://github.com/zengkun301/DCTLSA)						    | `dctlsa`						|
 | [SPAN](https://github.com/hongyuanyu/SPAN)							    | `span`						|


### PR DESCRIPTION
I simply noticed that in the readme, dat_light is still listed as an arch option, even though the arch registry definition for dat_light had been removed in the past from the dat_arch.py file.
Simply updating the readme accordingly.